### PR TITLE
Add sentry.apps entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
     test_suite='runtests.runtests',
     include_package_data=True,
     entry_points={
+        'sentry.apps': [
+            'sentry_hipchat = sentry_hipchat ',
+        ],
         'sentry.plugins': [
             'hipchat = sentry_hipchat.models:HipchatMessage',
          ],


### PR DESCRIPTION
Add a sentry.apps entry point for plugin registration (in at least Sentry 6.2.0).
