### PR TITLE
Removed v1 HipChat API support, implemented v2 support.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,7 @@ sentry-hipchat
 
 An extension for Sentry which integrates with Hipchat.
 It will send issues notification to Hipchat.
+Note: Current version only supports the HipChat v2 API, use older version of this plugin for v1 support.
 
 Install
 -------
@@ -15,5 +16,4 @@ Configuration
 -------------
 
 Go to your project's configuration page (Projects -> [Project]) and select the
-Hipchat tab. Enter the required credentials and click save changes.
-
+Hipchat tab. Enter the room ID and authentication token and you're ready to start receiving notifications.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 sentry-hipchat
 ==============
 
-An extension for Sentry which integrates with Hipchat. It will forwards
+An extension for Sentry which integrates with Hipchat v2. It will forwards
 notifications to an hipchat room.
 
 :copyright: (c) 2011 by the Linovia, see AUTHORS for more details.
@@ -23,8 +23,8 @@ install_requires = [
 
 setup(
     name='sentry-hipchat',
-    version='0.6.0',
-    author='Xavier Ordoquy',
+    version='0.7.0',
+    author='Xavier Ordoquy, Mitchell Klijnstra',
     author_email='xordoquy@linovia.com',
     url='http://github.com/linovia/sentry-hipchat',
     description='A Sentry extension which integrates with Hipchat.',


### PR DESCRIPTION
As we discussed in my previous PR, I removed the support for v1 completely. Have tested the plugin on our local sentry installs (6.x.x up to 7.7.0) and the functionality is the same as when there was still support for both API's when testing on the v2 API.

Note: Sorry about the duplicate request
