### PR TITLE
Doesn't work anymore with sentry 7.7.0, Fixed now

### DIFF
--- a/sentry_hipchat/models.py
+++ b/sentry_hipchat/models.py
@@ -10,7 +10,7 @@ from django import forms
 from django.conf import settings
 from django.utils.html import escape
 
-from sentry.plugins.bases.notify import NotifyPlugin
+from sentry.plugins.bases.notify import NotificationPlugin
 
 import sentry_hipchat
 
@@ -40,7 +40,7 @@ class HipchatOptionsForm(forms.Form):
                                widget=forms.TextInput(attrs={'placeholder': DEFAULT_ENDPOINT}))
 
 
-class HipchatMessage(NotifyPlugin):
+class HipchatMessage(NotificationPlugin):
     author = 'Xavier Ordoquy'
     author_url = 'https://github.com/linovia/sentry-hipchat'
     version = sentry_hipchat.VERSION


### PR DESCRIPTION
Doesn't work anymore with sentry 7.7.0, Fixed now

Sentry 7.7.0 is using NotificationPlugin as the parent class for a plugin. 

NotifyPlugin won't work anymore, even if you can import it and seems good, it just doesn't work.

This PR will fix this issue.
